### PR TITLE
Updated readme: Python >= 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ranwhen is a Python script that graphically shows **in your terminal** when your
 # Requirements
 
 * *nix system with [last(1)](http://linux.die.net/man/1/last) installed and supporting the -R and -F flags
-* [Python 3](http://www.python.org/)
+* [Python >= 3.2](http://www.python.org/)
 * Terminal emulator with support for Unicode and xterm's 256 color mode
 
 The above requirements should be fulfilled by default on the majority of modern Linux distributions, where the only thing that needs to be done is usually to install Python 3.

--- a/ranwhen.py
+++ b/ranwhen.py
@@ -4,7 +4,7 @@
 #
 # Requirements:
 # - *nix system with last(1) installed and supporting the -R and -F flags
-# - Python 3
+# - Python >= 3.2
 # - Terminal emulator with support for Unicode and xterm's 256 color mode
 #
 #


### PR DESCRIPTION
I tried to run the code (Python 3.1.2) and got this error:

```
Traceback (most recent call last):
  File "ranwhen.py", line 173, in <module>
    half_hours_in_day = round(day / half_hour)
TypeError: unsupported operand type(s) for /: 'datetime.timedelta' and 'datetime.timedelta'
```

Python 3.2 [added support](http://docs.python.org/3.2/library/datetime.html) for division between `timedelta`, so the I updated the readme file.
